### PR TITLE
Adjust for the viewport scrollX and scrollY

### DIFF
--- a/modules/components/MagicMove.js
+++ b/modules/components/MagicMove.js
@@ -104,8 +104,8 @@ var MagicMove = React.createClass({
       var marginTop = parseInt(computedStyle.marginTop, 10);
       var marginLeft = parseInt(computedStyle.marginLeft, 10);
       var position = {
-        top: (rect.top - marginTop),
-        left: (rect.left - marginLeft),
+        top: (rect.top - marginTop + window.scrollY),
+        left: (rect.left - marginLeft + window.scrollX),
         width: rect.width,
         height: rect.height,
         position: 'absolute'


### PR DESCRIPTION
Without this patch, if you scroll the basic example down and click the button to rearrange the boxes, the clones are rendered absolute to the document at the *viewport* coordinates of the real nodes. 

This causes them to be rendered higher on the page than the real nodes, and it looks like the boxes are jumping.

To fix this we need to convert the viewport coordinates to document coordinates by adding the scroll position.

I was surprised how few lines of code magic move was, it's pretty neat what you can do with React with that few lines!