### PR TITLE
Remove the uglifyjs dependency which causes npm install failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "reactify": "^0.17.1",
     "rf-release": "0.4.0",
     "uglify-js": "^2.4.15",
-    "uglifyjs": "^2.3.6",
     "webpack": "1.4.5",
     "webpack-dev-server": "1.6.5"
   },


### PR DESCRIPTION
Apparently the uglifyjs dependency has been removed from npm:

https://www.npmjs.com/package/uglifyjs

The uglify-js library provides that `uglifyjs` executable that you use to build magic move, so I don't see anything that would break by removing this